### PR TITLE
Recreate `covid_case_death_rates*` objects with a newer as-of date to get rid of an erroneous negative value

### DIFF
--- a/R/epipredict-data.R
+++ b/R/epipredict-data.R
@@ -3,7 +3,7 @@
 #' This data source of confirmed COVID-19 cases and deaths is based on reports
 #' made available by the Center for Systems Science and Engineering at Johns
 #' Hopkins University, as downloaded from the CMU Delphi COVIDcast Epidata
-#' API. This example data is a snapshot as of May 31, 2022, and
+#' API. This example data is a snapshot as of Jan 27, 2025, and
 #' ranges from December 31, 2020 to December 31, 2021. It
 #' includes all states.
 #'

--- a/R/epiprocess-data.R
+++ b/R/epiprocess-data.R
@@ -214,7 +214,7 @@
 #' This data source of confirmed COVID-19 cases and deaths is based on reports
 #' made available by the Center for Systems Science and Engineering at Johns
 #' Hopkins University, as downloaded from the CMU Delphi COVIDcast Epidata
-#' API. This example data is a snapshot as of May 31, 2022, and
+#' API. This example data is a snapshot as of Jan 27, 2025, and
 #' ranges from March 1, 2020 to December 31, 2021. It
 #' includes all states.
 #'

--- a/data-raw/covid_case_death_rates_extension_tbl.R
+++ b/data-raw/covid_case_death_rates_extension_tbl.R
@@ -3,7 +3,7 @@ library(epidatr)
 
 source(here::here("data-raw/_helper.R"))
 
-d <- as.Date("2022-05-31")
+d <- as.Date("2025-01-27")
 
 x <- pub_covidcast(
   source = "jhu-csse",

--- a/data-raw/covid_case_death_rates_tbl.R
+++ b/data-raw/covid_case_death_rates_tbl.R
@@ -3,7 +3,7 @@ library(epidatr)
 
 source(here::here("data-raw/_helper.R"))
 
-d <- as.Date("2022-05-31")
+d <- as.Date("2025-01-27")
 
 x <- pub_covidcast(
   source = "jhu-csse",

--- a/man/covid_case_death_rates.Rd
+++ b/man/covid_case_death_rates.Rd
@@ -34,7 +34,7 @@ covid_case_death_rates
 This data source of confirmed COVID-19 cases and deaths is based on reports
 made available by the Center for Systems Science and Engineering at Johns
 Hopkins University, as downloaded from the CMU Delphi COVIDcast Epidata
-API. This example data is a snapshot as of May 31, 2022, and
+API. This example data is a snapshot as of Jan 27, 2025, and
 ranges from December 31, 2020 to December 31, 2021. It
 includes all states.
 }

--- a/man/covid_case_death_rates_extended.Rd
+++ b/man/covid_case_death_rates_extended.Rd
@@ -34,7 +34,7 @@ covid_case_death_rates_extended
 This data source of confirmed COVID-19 cases and deaths is based on reports
 made available by the Center for Systems Science and Engineering at Johns
 Hopkins University, as downloaded from the CMU Delphi COVIDcast Epidata
-API. This example data is a snapshot as of May 31, 2022, and
+API. This example data is a snapshot as of Jan 27, 2025, and
 ranges from March 1, 2020 to December 31, 2021. It
 includes all states.
 }


### PR DESCRIPTION
The negative value was removed in a later issue.