### PR TITLE
updating covid_cases_deaths

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: epidatasets
 Title: Epidemiological Data for Delphi Tooling Examples
-Version: 0.0.1
+Version: 0.0.2
 Authors@R: c(
     person(c("Daniel", "J."), "McDonald", , "daniel@stat.ubc.ca", role = "aut"),
     person("Nat", "DeFries", , "ndefries@andrew.cmu.edu", role = c("cre", "aut")),

--- a/R/epipredict-data.R
+++ b/R/epipredict-data.R
@@ -3,7 +3,7 @@
 #' This data source of confirmed COVID-19 cases and deaths is based on reports
 #' made available by the Center for Systems Science and Engineering at Johns
 #' Hopkins University, as downloaded from the CMU Delphi COVIDcast Epidata
-#' API. This example data is a snapshot as of May 31, 2022, and
+#' API. This example data is a snapshot as of March 10, 2023, and
 #' ranges from December 31, 2020 to December 31, 2021. It
 #' includes all states.
 #'

--- a/R/epiprocess-data.R
+++ b/R/epiprocess-data.R
@@ -214,7 +214,7 @@
 #' This data source of confirmed COVID-19 cases and deaths is based on reports
 #' made available by the Center for Systems Science and Engineering at Johns
 #' Hopkins University, as downloaded from the CMU Delphi COVIDcast Epidata
-#' API. This example data is a snapshot as of May 31, 2022, and
+#' API. This example data is a snapshot as of March 10, 2023, and
 #' ranges from March 1, 2020 to December 31, 2021. It
 #' includes all states.
 #'

--- a/data-raw/covid_case_death_rates_extension_tbl.R
+++ b/data-raw/covid_case_death_rates_extension_tbl.R
@@ -3,7 +3,7 @@ library(epidatr)
 
 source(here::here("data-raw/_helper.R"))
 
-d <- as.Date("2022-05-31")
+d <- as.Date("2023-03-10")
 
 x <- pub_covidcast(
   source = "jhu-csse",

--- a/data-raw/covid_case_death_rates_tbl.R
+++ b/data-raw/covid_case_death_rates_tbl.R
@@ -3,7 +3,7 @@ library(epidatr)
 
 source(here::here("data-raw/_helper.R"))
 
-d <- as.Date("2022-05-31")
+d <- as.Date("2023-03-10")
 
 x <- pub_covidcast(
   source = "jhu-csse",

--- a/data/covid_case_death_rates.R
+++ b/data/covid_case_death_rates.R
@@ -1,6 +1,6 @@
 delayedAssign("covid_case_death_rates", local({
   if (requireNamespace("epiprocess", quietly = TRUE)) {
-    d <- as.Date("2022-05-31")
+    d <- as.Date("2023-03-10")
     epiprocess::as_epi_df(epidatasets:::covid_case_death_rates_tbl, as_of = d)
   } else {
     warning("Since the package `epiprocess` is not installed, this object will be loaded as a tibble (class `tbl_df`)")

--- a/data/covid_case_death_rates_extended.R
+++ b/data/covid_case_death_rates_extended.R
@@ -1,6 +1,6 @@
 delayedAssign("covid_case_death_rates_extended", local({
   if (requireNamespace("epiprocess", quietly = TRUE)) {
-    d <- as.Date("2022-05-31")
+    d <- as.Date("2023-03-10")
     epiprocess::as_epi_df(
       dplyr::bind_rows(
         epidatasets:::covid_case_death_rates_extension_tbl,

--- a/man/covid_case_death_rates.Rd
+++ b/man/covid_case_death_rates.Rd
@@ -34,7 +34,7 @@ covid_case_death_rates
 This data source of confirmed COVID-19 cases and deaths is based on reports
 made available by the Center for Systems Science and Engineering at Johns
 Hopkins University, as downloaded from the CMU Delphi COVIDcast Epidata
-API. This example data is a snapshot as of May 31, 2022, and
+API. This example data is a snapshot as of March 10, 2023, and
 ranges from December 31, 2020 to December 31, 2021. It
 includes all states.
 }

--- a/man/covid_case_death_rates_extended.Rd
+++ b/man/covid_case_death_rates_extended.Rd
@@ -34,7 +34,7 @@ covid_case_death_rates_extended
 This data source of confirmed COVID-19 cases and deaths is based on reports
 made available by the Center for Systems Science and Engineering at Johns
 Hopkins University, as downloaded from the CMU Delphi COVIDcast Epidata
-API. This example data is a snapshot as of May 31, 2022, and
+API. This example data is a snapshot as of March 10, 2023, and
 ranges from March 1, 2020 to December 31, 2021. It
 includes all states.
 }


### PR DESCRIPTION
Since JHU-CSSE is archived, we may as well use the most up to date version for any of the extant examples. This updates `covid_case_death_rates` and `covid_case_death_rates_extension` to the last version of the data