### PR TITLE
deps: remove covidcast dependency

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,3 +1,5 @@
+^renv$
+^renv\.lock$
 ^.*\.Rproj$
 ^\.Rproj\.user$
 ^data-raw$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: epidatasets
 Title: Epidemiological Data for Delphi Tooling Examples
-Version: 0.0.2
+Version: 0.0.3
 Authors@R: c(
     person(c("Daniel", "J."), "McDonald", , "daniel@stat.ubc.ca", role = "aut"),
     person("Nat", "DeFries", , "ndefries@andrew.cmu.edu", role = c("cre", "aut")),
@@ -27,8 +27,7 @@ URL: https://github.com/cmu-delphi/epidatasets,
     https://cmu-delphi.github.io/epidatasets/
 Depends:
     R (>= 2.10)
-Suggests: 
-    covidcast,
+Suggests:
     data.table,
     dplyr,
     epidatr,

--- a/data-raw/covid_incidence_county_subset_tbl.R
+++ b/data-raw/covid_incidence_county_subset_tbl.R
@@ -5,7 +5,9 @@ source(here::here("data-raw/_helper.R"))
 
 d <- as.Date("2024-03-20")
 
-# Previously, we were using `covidcast::county_census`, but covidcast is large and complicated to install (due to `sf` dependency). Instead, read the file directly from GitHub.
+# Previously, we were using `covidcast::county_census`, but covidcast is large
+# and complicated to install (due to `sf` dependency). Instead, read the file
+# directly from GitHub.
 y <- read_csv("https://github.com/cmu-delphi/covidcast/raw/c89e4d295550ba1540d64d2cc991badf63ad04e5/Python-packages/covidcast-py/covidcast/geo_mappings/county_census.csv", # nolint: line_length_linter
   col_types = cols(
     FIPS = col_character(),

--- a/data-raw/state_census.R
+++ b/data-raw/state_census.R
@@ -1,7 +1,10 @@
 library(dplyr)
 library(covidcast)
 
-state_census <- covidcast::state_census %>%
+# Previously, we were using `covidcast::county_census`, but covidcast is large
+# and complicated to install (due to `sf` dependency). Instead, read the file
+# directly from GitHub.
+state_census <- read_csv("https://github.com/cmu-delphi/covidcast/raw/c89e4d295550ba1540d64d2cc991badf63ad04e5/Python-packages/covidcast-py/covidcast/geo_mappings/state_census.csv") %>% # nolint: line_length_linter
   select(STATE, NAME, POPESTIMATE2019, ABBR) %>%
   rename(abbr = ABBR, name = NAME, pop = POPESTIMATE2019, fips = STATE) %>%
   # Left-pad FIPS codes with zeroes to 2 digits, and convert to character


### PR DESCRIPTION
Since the work in and related #7, we don't use `covidcast` anymore, so remove it from Suggests (it brings tons of bloated dependencies).

closes #7 